### PR TITLE
fix(text-field): Fix `behavior` attribute

### DIFF
--- a/lib/coprl/presenters/dsl/components/text_field.rb
+++ b/lib/coprl/presenters/dsl/components/text_field.rb
@@ -50,11 +50,6 @@ module Coprl
             @hint = hint
           end
 
-          def behavior
-            return "type=\"#{@behavior}\"" unless @behavior == 'currency'
-            return 'type="number" min="0.00" max="10000000000.00" step="0.01"'
-          end
-
           private
 
           def json_regexp(regexp)

--- a/views/mdc/components/_text_field.erb
+++ b/views/mdc/components/_text_field.erb
@@ -2,7 +2,14 @@
      leading_icon = comp.icon && comp.icon.position.select {|p| eq(p, :left)}.any?
      trailing_icon = comp.icon && comp.icon.position.select {|p| eq(p, :right)}.any?
      auto_complete = comp.auto_complete&.to_sym == :off ? 'extra-off' : comp.auto_complete
-     behavior = comp.behavior || 'text'
+     behavior_tag = case comp.behavior&.to_s
+                    when 'currency', 'money'
+                      'type="number" min="0.00" max="10000000000.00" step="0.01"'
+                    when 'percent', 'percentage'
+                      'type="number" min="0" max="100" step="0.1"'
+                    else
+                      "type=\"#{comp.behavior || 'text'}\""
+                    end
 %>
   <div id="<%= comp.id %>"
        <% if comp.input_tag %>data-input-tag="<%= comp.input_tag %>"<% end %>
@@ -16,7 +23,7 @@
 
     <input id="<%= comp.id %>-input"
            name="<%= comp.name %>"
-           <%= behavior %>
+           <%= behavior_tag %>
            value="<%= comp.value %>"
            class="mdc-text-field__input"
            aria-controls="<%= comp.id %>-input-helper-text"
@@ -36,4 +43,3 @@
   <%= partial "components/shared/hint_error_display", :locals => {comp: comp} %>
   <%= partial "components/tooltip", :locals => {comp: comp.tooltip, parent_id: comp.id} if comp.tooltip %>
 <% end %>
-


### PR DESCRIPTION
fix(text-field): Fix `behavior` attribute

The `TextField#behavior` method, which returned markup, was being masked by the class's `attr_reader :behavior` definition, which returned the attribute value passed in by the caller, resulting in markup similar to this
```html
<input name="something" email>
```
instead of
```html
<input name="something" type="email">
```
While not broken, this resulted in incorrect behavior on the client.

This change moves the markup into the ERB layer, removing the clashing method definition entirely.