### PR TITLE
feat(select): add support for `no-label`

### DIFF
--- a/views/mdc/components/_select.erb
+++ b/views/mdc/components/_select.erb
@@ -1,43 +1,43 @@
-<% if comp
-  float_label = comp.options.select{|o| o.selected }.any?
-%>
-  <div class="mdc-select v-select v-input
-              <%= 'mdc-select--outlined' if comp.outlined %>
-              <% if comp.disabled %>mdc-select--disabled<% end %>"
-       <% if comp.input_tag %>data-input-tag="<%= comp.input_tag %>"<% end %>
-       <% if comp.dirtyable %>data-dirtyable<% end %>
-       <%= 'style="width: 100%;"' if comp.full_width %>>
-    <%= partial "components/icon", :locals => {comp: comp.icon, class_name: 'mdc-select__icon', parent_id: "#{comp.id}-input", size_class: '', position: []} if comp.icon %>
-    <i class="mdc-select__dropdown-icon"></i>
-    <select id="<%= comp.id %>-input"
-            <% if comp.name %> name="<%= comp.name %>" <% end %>
-            <% if comp.required %>required<% end %>
-            <% if comp.disabled %>disabled<% end %>
-            class="mdc-select__native-control"
-            <%= partial("components/event", locals: {comp: comp,
-                                                  events: comp.events,
-                                                  parent_id: "#{comp.id}-input"}) if comp.events&.any? %>>
-      <% comp.options.each do |option| %>
-        <option value="<%= option.value %>"
-                <%= 'disabled' if option.disabled %>
-                <%= 'selected' if option.selected %>>
-          <%= option.text %>
-        </option>
-      <% end %>
-    </select>
-    <% if comp.outlined %>
-      <div class="mdc-notched-outline">
-        <div class="mdc-notched-outline__leading"></div>
-        <div class="mdc-notched-outline__notch">
-          <label class="mdc-floating-label <%= 'mdc-floating-label--float-above' if float_label %>"><%= comp.label %></label>
-        </div>
-        <div class="mdc-notched-outline__trailing"></div>
-      </div>
-    <% else %>
-      <label class="mdc-floating-label <%= 'mdc-floating-label--float-above' if float_label %>"><%= comp.label %></label>
-      <div class="mdc-line-ripple"></div>
+<% float_label = comp.options.any?(&:selected) %>
+<div class="mdc-select v-select v-input
+            <%= 'mdc-select--outlined' if comp.outlined %>
+            <% if comp.disabled %>mdc-select--disabled<% end %>
+            <% unless comp.label %>mdc-select--no-label<% end %>"
+     <% if comp.input_tag %>data-input-tag="<%= comp.input_tag %>"<% end %>
+     <% if comp.dirtyable %>data-dirtyable<% end %>
+     <%= 'style="width: 100%;"' if comp.full_width %>>
+  <%= partial "components/icon", :locals => {comp: comp.icon, class_name: 'mdc-select__icon', parent_id: "#{comp.id}-input", size_class: '', position: []} if comp.icon %>
+  <select id="<%= comp.id %>-input"
+          <% if comp.name %> name="<%= comp.name %>" <% end %>
+          <% if comp.required %>required<% end %>
+          <% if comp.disabled %>disabled<% end %>
+          class="mdc-select__native-control"
+          <%= partial("components/event", locals: {comp: comp,
+                                                events: comp.events,
+                                                parent_id: "#{comp.id}-input"}) if comp.events&.any? %>>
+    <% comp.options.each do |option| %>
+      <option value="<%= option.value %>"
+              <%= 'disabled' if option.disabled %>
+              <%= 'selected' if option.selected %>>
+        <%= option.text %>
+      </option>
     <% end %>
-  </div>
-  <%= partial "components/shared/hint_error_display", :locals => {comp: comp} %>
-  <%= partial "components/tooltip", :locals => {comp: comp.tooltip, parent_id: comp.id} if comp.tooltip %>
-<% end %>
+  </select>
+  <i class="mdc-select__dropdown-icon"></i>
+  <% if comp.outlined %>
+    <span class="mdc-notched-outline">
+      <span class="mdc-notched-outline__leading"></span>
+        <span class="mdc-notched-outline__notch">
+          <% if comp.label %><label class="mdc-floating-label <%= 'mdc-floating-label--float-above' if float_label %>"><%= comp.label %></label><% end %>
+        </span>
+      <span class="mdc-notched-outline__trailing"></span>
+    </span>
+  <% else %>
+    <% if comp.label %>
+      <label class="mdc-floating-label <%= 'mdc-floating-label--float-above' if float_label %>"><%= comp.label %></label>
+    <% end %>
+    <span class="mdc-line-ripple"></span>
+  <% end %>
+</div>
+<%= partial "components/shared/hint_error_display", :locals => {comp: comp} %>
+<%= partial "components/tooltip", :locals => {comp: comp.tooltip, parent_id: comp.id} if comp.tooltip %>


### PR DESCRIPTION
may want to turn off whitespace diff for this one – the whole file was unindented.

---

feat(select): add support for `no-label`

Aligns the select component with the MDC web example markup when no `label` DSL component is present in the `select` component.

Previously, when not specifying a label for a `select`, the generated markup would result in an "empty" MDC outline notch where the label text (an empty string) should be. This change adds the `mdc-select--no-label` class to the component's element and only renders the `floating-label` MDC element if the user has explicitly provided a `label` in the DSL.

---

Example:
```ruby
select full_width: false do
  1.upto 10 do |n|
    option n
  end
end
```

before/after:
![Screen Shot 2021-11-02 at 10 30 50](https://user-images.githubusercontent.com/29804640/139867359-3ecdf406-22b8-4b1f-81bb-d591d73be2ec.png) ![Screen Shot 2021-11-02 at 10 31 20](https://user-images.githubusercontent.com/29804640/139867378-654c30f1-4d5a-4183-bea4-43dc178a555b.png)