### PR TITLE
feat(grid): expand grid/column alignment

### DIFF
--- a/lib/coprl/presenters/dsl/components/grid.rb
+++ b/lib/coprl/presenters/dsl/components/grid.rb
@@ -8,16 +8,21 @@ module Coprl
           include Mixins::Snackbars
           include Mixins::Progress
           include Mixins::Padding
+          include Mixins::Alignment
 
-          attr_reader   :columns,
-                        :color,
-                        :padding,
-                        :wide,
-                        :gutter,
-                        :height
+          attr_reader :columns,
+                      :color,
+                      :padding,
+                      :wide,
+                      :gutter,
+                      :height,
+                      :direction,
+                      :align,
+                      :justify
 
           def initialize(color: nil, **attribs_, &block)
             super(type: :grid, **attribs_, &block)
+
             @columns = []
             @color = color
             padding = attribs.delete(:padding) {nil}
@@ -25,13 +30,16 @@ module Coprl
             @wide = attribs.delete(:wide) {false}
             @gutter = coerce_gutter(attribs.delete(:gutter) {nil})
             @height = attribs.delete(:height) {nil}
+            @direction = validate_direction!(attribs.delete(:direction) { :row })
+            @align = validate_alignment!(attribs.delete(:align) { :stretch })
+            @justify = validate_alignment!(attribs.delete(:justify) { :stretch })
+
             expand!
           end
 
           def column(size, color: nil, **attribs, &block)
             attribs = size.respond_to?(:keys) ? attribs.merge(size) : attribs.merge(size: size)
-            @columns << Column.new(parent: self, color: color,
-                                   **attribs, &block)
+            @columns << Column.new(parent: self, color: color, **attribs, &block)
           end
 
           private
@@ -45,12 +53,12 @@ module Coprl
             when nil
               nil
             else
-              raise Errors::ParameterValidation, "Grid gutter was: #{gutter}. "\
-                          'Allowed gutter values are true, false, :full, :all, :none! and nil'
+              raise Errors::ParameterValidation,
+                    "Grid gutter was: #{gutter}. Allowed gutter values are " \
+                    "true, false, :full, :all, :none and nil."
             end
           end
 
-          include Mixins::Padding
           class Column < EventBase
             include Mixins::Common
             include Mixins::Icons
@@ -68,6 +76,7 @@ module Coprl
             include Mixins::Avatar
             include Mixins::Progress
             include Mixins::Padding
+            include Mixins::Alignment
 
             attr_reader :size,
                         :desktop,
@@ -76,31 +85,30 @@ module Coprl
                         :color,
                         :components,
                         :padding,
+                        :direction,
                         :align,
+                        :justify,
                         :overflow,
                         :height
 
             def initialize(**attribs_, &block)
               super(type: :column, **attribs_, &block)
+
               @size = attribs.delete(:size) || 1
               @desktop = attribs.delete(:desktop)
               @tablet = attribs.delete(:tablet)
               @phone = attribs.delete(:phone)
               @color = attribs.delete(:color)
-              @align = validate_alignment(attribs.delete(:align) {:left})
+              @direction = validate_direction!(attribs.delete(:direction)) if attribs[:direction]
+              @align = validate_alignment!(attribs.delete(:align)) if attribs[:align]
+              @justify = validate_alignment!(attribs.delete(:justify)) if attribs[:justify]
               @overflow = attribs.delete(:overflow){true}
               @components = []
               padding = attribs.delete(:padding) {nil}
               @padding = validate_padding!(coerce_padding(padding)).uniq if padding != nil
               @height = attribs.delete(:height) {nil}
-              expand!
-            end
 
-            def validate_alignment(align)
-              valid_alignment = %i(right left)
-              raise "Invalid value for column alignment: #{align}. "\
-                      "Valid values are #{valid_alignment.join(' ,')}." unless valid_alignment.include?(align)
-              align
+              expand!
             end
           end
         end

--- a/lib/coprl/presenters/dsl/components/mixins/alignment.rb
+++ b/lib/coprl/presenters/dsl/components/mixins/alignment.rb
@@ -1,0 +1,41 @@
+module Coprl::Presenters::DSL::Components::Mixins
+  module Alignment
+    private
+
+    DIRECTIONS = %i[row column].freeze
+    ALIGNMENTS = %i[start center end stretch].freeze
+
+    DIRECTIONS_STRING = DIRECTIONS.map(&:inspect).join(', ').freeze
+    ALIGNMENTS_STRING = ALIGNMENTS.map(&:inspect).join(', ').freeze
+    DEPRECATED_ALIGNMENTS = {left: :start, right: :end}.freeze
+
+    def validate_direction!(direction)
+      return unless direction
+
+      sym = direction.to_sym
+
+      unless DIRECTIONS.include?(sym)
+        raise Coprl::Presenters::Errors::InvalidDsl,
+              "Invalid direction: expected one of #{DIRECTIONS_STRING}"
+      end
+
+      sym
+    end
+
+    def validate_alignment!(alignment)
+      return unless alignment
+
+      sym = alignment.to_sym
+
+      if DEPRECATED_ALIGNMENTS.key?(sym)
+        logger.warn ':left and :right grid/column alignments are deprecated ' \
+                    'and will be removed in a future release. Please migrate ' \
+                    "usages to one of #{ALIGNMENTS_STRING}."
+
+        sym = DEPRECATED_ALIGNMENTS[sym]
+      end
+
+      sym
+    end
+  end
+end

--- a/lib/coprl/presenters/web_client/helpers/alignment_helpers.rb
+++ b/lib/coprl/presenters/web_client/helpers/alignment_helpers.rb
@@ -1,0 +1,46 @@
+module Coprl::Presenters::WebClient::Helpers
+  module AlignmentHelpers
+    private
+
+    # controls content alignment (how items are laid out along a grid's block
+    # axis) for an entire grid.
+    def grid_align_class(value)
+      return unless value
+      "v-grid--align-#{value}"
+    end
+
+    # controls content justification (how items are laid out along the grid's
+    # inline axis) for an entire grid.
+    def grid_justify_class(value)
+      return unless value
+      "v-grid--justify-#{value}"
+    end
+
+    # controls content flow/direction for an entire grid.
+    def grid_direction_class(value)
+      return unless value
+      "v-grid--direction-#{value}"
+    end
+
+    # controls content alignment for a single column, overriding any value set
+    # for the column's parent grid.
+    def column_align_class(value)
+      return unless value
+      "v-column--align-#{value}"
+    end
+
+    # controls content justification for a single column, overriding any value
+    # set for the column's parent grid.
+    def column_justify_class(value)
+      return unless value
+      "v-column--justify-#{value}"
+    end
+
+    # controls content flow/direction for a single column, overriding any value
+    # set for the column's parent grid.
+    def column_direction_class(value)
+      return unless value
+      "v-grid-column--direction-#{value}"
+    end
+  end
+end

--- a/lib/coprl/presenters/web_client/helpers/padding_helpers.rb
+++ b/lib/coprl/presenters/web_client/helpers/padding_helpers.rb
@@ -16,10 +16,6 @@ module Coprl::Presenters::WebClient::Helpers
       padding_array(padding, nesting).map { |p| "v-padding--#{p}" }.join(' ')
     end
 
-    def alignment_class(align)
-      "v-grid-column-align-#{align}"
-    end
-
     private
 
     NUMBER = %r{\d}.freeze

--- a/lib/coprl/presenters/web_client/helpers/shared.rb
+++ b/lib/coprl/presenters/web_client/helpers/shared.rb
@@ -14,5 +14,6 @@ module Coprl::Presenters::WebClient::Helpers
     include SnakeToCamel
     include DragAndDrop
     include TransformHash
+    include AlignmentHelpers
   end
 end

--- a/public/bundle.css
+++ b/public/bundle.css
@@ -7335,7 +7335,7 @@ svg.mdc-button__icon {
   /* @alternate */
   background-color: var(--mdc-theme-secondary, #E58D36); }
 
-@keyframes mdc-checkbox-fade-in-background-ub7a10a8e {
+@keyframes mdc-checkbox-fade-in-background-u560bc96a {
   0% {
     border-color: rgba(0, 0, 0, 0.54);
     background-color: transparent; }
@@ -7347,7 +7347,7 @@ svg.mdc-button__icon {
     /* @alternate */
     background-color: var(--mdc-theme-secondary, #E58D36); } }
 
-@keyframes mdc-checkbox-fade-out-background-ub7a10a8e {
+@keyframes mdc-checkbox-fade-out-background-u560bc96a {
   0%,
   80% {
     border-color: #E58D36;
@@ -7361,10 +7361,10 @@ svg.mdc-button__icon {
     background-color: transparent; } }
 
 .mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-in-background-ub7a10a8e; }
+  animation-name: mdc-checkbox-fade-in-background-u560bc96a; }
 
 .mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-out-background-ub7a10a8e; }
+  animation-name: mdc-checkbox-fade-out-background-u560bc96a; }
 
 .mdc-checkbox__checkmark {
   color: #fff; }
@@ -14345,7 +14345,7 @@ button.mdc-chip {
   /* @alternate */
   background-color: var(--mdc-theme-primary, #5488b2); }
 
-@keyframes mdc-checkbox-fade-in-background-uf14c7205 {
+@keyframes mdc-checkbox-fade-in-background-u9c178962 {
   0% {
     border-color: rgba(0, 0, 0, 0.54);
     background-color: transparent; }
@@ -14357,7 +14357,7 @@ button.mdc-chip {
     /* @alternate */
     background-color: var(--mdc-theme-primary, #5488b2); } }
 
-@keyframes mdc-checkbox-fade-out-background-uf14c7205 {
+@keyframes mdc-checkbox-fade-out-background-u9c178962 {
   0%,
   80% {
     border-color: #5488b2;
@@ -14373,12 +14373,12 @@ button.mdc-chip {
 .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-in-background-uf14c7205; }
+  animation-name: mdc-checkbox-fade-in-background-u9c178962; }
 
 .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-out-background-uf14c7205; }
+  animation-name: mdc-checkbox-fade-out-background-u9c178962; }
 
 .mdc-data-table .mdc-list-item__graphic {
   margin-right: 0px; }
@@ -16670,6 +16670,66 @@ i:focus.v-datetime--clear {
 
 .ql-container.ql-snow {
   border: 1px solid #ccc; }
+
+.v-grid--direction-row {
+  grid-auto-flow: row; }
+
+.v-column--direction-row {
+  grid-auto-flow: row; }
+
+.v-grid--direction-column {
+  grid-auto-flow: column; }
+
+.v-column--direction-column {
+  grid-auto-flow: column; }
+
+.v-grid--align-start {
+  justify-items: start !important; }
+
+.v-grid--justify-start {
+  align-items: start !important; }
+
+.v-column--align-start {
+  justify-self: start !important; }
+
+.v-column--justify-start {
+  align-self: start !important; }
+
+.v-grid--align-center {
+  justify-items: center !important; }
+
+.v-grid--justify-center {
+  align-items: center !important; }
+
+.v-column--align-center {
+  justify-self: center !important; }
+
+.v-column--justify-center {
+  align-self: center !important; }
+
+.v-grid--align-end {
+  justify-items: end !important; }
+
+.v-grid--justify-end {
+  align-items: end !important; }
+
+.v-column--align-end {
+  justify-self: end !important; }
+
+.v-column--justify-end {
+  align-self: end !important; }
+
+.v-grid--align-stretch {
+  justify-items: stretch !important; }
+
+.v-grid--justify-stretch {
+  align-items: stretch !important; }
+
+.v-column--align-stretch {
+  justify-self: stretch !important; }
+
+.v-column--justify-stretch {
+  align-self: stretch !important; }
 
 :root {
   --mdc-layout-grid-margin-desktop: 24px;

--- a/views/mdc/assets/scss/alignment.scss
+++ b/views/mdc/assets/scss/alignment.scss
@@ -1,0 +1,37 @@
+$directions: (row, column);
+$alignments: (start, center, end, stretch);
+
+@each $direction in $directions {
+  .v-grid--direction-#{$direction} {
+    grid-auto-flow: $direction;
+  }
+
+  .v-column--direction-#{$direction} {
+    grid-auto-flow: $direction;
+  }
+}
+
+@each $value in $alignments {
+  // yes, these are intentionally backwards. we want `align` to control
+  // horizontal placement for LTR and RTL layouts and `justify` to control
+  // vertical placement.
+  // this is an intentional deviation from the CSS box alignment spec: to COPRL
+  // (which is more than just the HTML+JS+CSS "web client"), `align` controls
+  // the equivalent of the CSS "inline" axis and `justify` controls the block
+  // axis.
+  .v-grid--align-#{$value} {
+    justify-items: $value !important;
+  }
+
+  .v-grid--justify-#{$value} {
+    align-items: $value !important;
+  }
+
+  .v-column--align-#{$value} {
+    justify-self: $value !important;
+  }
+
+  .v-column--justify-#{$value} {
+    align-self: $value !important;
+  }
+}

--- a/views/mdc/assets/scss/app.scss
+++ b/views/mdc/assets/scss/app.scss
@@ -45,5 +45,6 @@
 @import "components/rich-text-area";
 @import "components/vendor/quill.snow";
 
+@import "alignment";
 @import "padding";
 @import "styles";

--- a/views/mdc/components/_grid.erb
+++ b/views/mdc/components/_grid.erb
@@ -1,14 +1,12 @@
 <%
   @grid_nesting ||= 0
   @grid_nesting += 1
-   @gutters ||= [true]
-   # gutters once turned off are turned off for all nested grids
-   @gutters.push comp.gutter.nil? ? @gutters.last : comp.gutter
+  @gutters ||= [true]
+  # gutters once turned off are turned off for all nested grids
+  @gutters.push comp.gutter.nil? ? @gutters.last : comp.gutter
 %>
 <div id="<%= comp.id %>"
-     <% if comp.input_tag %>
-     data-input-tag="<%= comp.input_tag %>"
-     <% end %>
+     <% if comp.input_tag %>data-input-tag="<%= comp.input_tag %>"<% end %>
      class="v-grid mdc-layout-grid
             <%= padding_classes(comp.padding, @grid_nesting) %>
             <%= 'v-grid__wide' if comp.wide %>
@@ -17,23 +15,13 @@
      <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.event_parent_id} if comp.events&.any? %>>
   <%= partial("components/progress", :locals => {:comp => comp.progress}) if comp.progress && includes_one?(Array(comp.progress.position), %i(top both))%>
 
-  <div class="<%= @gutters.last ? nil : 'v-gutter-none' %> mdc-layout-grid__inner"
+  <div class="<%= @gutters.last ? nil : 'v-gutter-none' %> mdc-layout-grid__inner
+              <%= grid_direction_class(comp.direction) %>
+              <%= grid_align_class(comp.align) %>
+              <%= grid_justify_class(comp.justify) %>"
        style="<%= "height:#{comp.height};" if comp.height %>">
-    <% comp.columns.each do |col|
-      span = "mdc-layout-grid__cell--span-#{col.size}"
-      %i(desktop tablet phone).each do |device|
-        span << " mdc-layout-grid__cell--span-#{col.send(device)}-#{device}" if col.send(device)
-      end
-     %>
-      <div id="<%= col.id %>" class="v-column mdc-layout-grid__cell <%= span %>
-                          <%= col.overflow ? nil : 'v-column-hide-overflow' %>
-                          <%= padding_classes(col.padding) %> v-column--relative <%= alignment_class(col.align) %> <%= col.css_class.join(' ') %>"
-           style="<%= "background-color: #{col.color};" if col.color %><%= "height:#{comp.height};" if comp.height %>"
-        <%= partial "components/event", :locals => {comp: col, events: col.events, parent_id: col.event_parent_id} if col.events&.any? %>>
-        <%= partial("components/progress", :locals => {:comp => col.progress}) if col.progress && includes_one?(Array(col.progress.position), %i(top both))%>
-        <%= partial "components/render", :locals => {:components => col.components, :scope => nil} if col.components.any? %>
-        <%= partial("components/progress", :locals => {:comp => col.progress}) if col.progress && includes_one?(Array(col.progress.position), %i(bottom both))%>
-      </div>
+    <% comp.columns.each do |col| %>
+      <%= partial 'components/grid/column', locals: {comp: col} %>
     <% end %>
   </div>
   <%= partial("components/progress", :locals => {:comp => comp.progress}) if comp.progress && includes_one?(Array(comp.progress.position), %i(bottom both))%>

--- a/views/mdc/components/grid/_column.erb
+++ b/views/mdc/components/grid/_column.erb
@@ -1,0 +1,22 @@
+<%
+  devices = %i[desktop tablet phone]
+  span_classes = "mdc-layout-grid__cell--span-#{comp.size}"
+  devices.each do |device|
+    span_classes << " mdc-layout-grid__cell--span-#{comp.send(device)}-#{device}" if comp.send(device)
+  end
+%>
+<div id="<%= comp.id %>"
+     class="v-column v-column--relative mdc-layout-grid__cell
+     <%= span_classes %>
+     <%= comp.overflow ? nil : 'v-column-hide-overflow' %>
+     <%= padding_classes(comp.padding) %>
+     <%= column_direction_class(comp.direction) %>
+     <%= column_align_class(comp.align) %>
+     <%= column_justify_class(comp.justify) %>
+     <%= comp.css_class.join(' ') %>"
+     style="<%= "background-color: #{comp.color};" if comp.color %><%= "height:#{comp.height};" if comp.height %>"
+  <%= partial "components/event", locals: {comp: comp, events: comp.events, parent_id: comp.event_parent_id} if comp.events&.any? %>>
+  <%= partial("components/progress", locals: {comp: comp.progress}) if comp.progress && includes_one?(Array(comp.progress.position), %i(top both))%>
+  <%= partial "components/render", locals: {components: comp.components, scope: nil} if comp.components.any? %>
+  <%= partial("components/progress", locals: {comp: comp.progress}) if comp.progress && includes_one?(Array(comp.progress.position), %i(bottom both))%>
+</div>


### PR DESCRIPTION
feat(grid): expand grid/column alignment

Grid/column alignment has been split into two properties: `align` and
`justify`.

`align` controls the layout of grid columns or column content along
the horizontal axis (for LTR and RTL layouts) and `justify` controls
the vertical axis.

Notably, this is a deliberate departure from the CSS box alignment
specification for grids, which behaves the opposite.

`:left` and `:right` grid/column alignment have been deprecated and
replaced with `:start`, `:center`, `:end`, and `:stretch` to better
support non-LTR layouts. To maintain backward compatibility, `:left` and
`:right` are mapped to `:start` and `:end`, respectively, and a
deprecation warning is emitted via the logger.

For example, this POM code

    grid do
      column align: :end, justify: :center do
      end
    end

results in a column with (for a left-to-right layout) right-aligned and
vertically centered content. For a user with a right-to-left layout,
this column's contents would be left-aligned.

The default values for `align` and `justify` are introduced as
`:stretch` to maintain backward compatibility.

Introduce grid/column `direction` attribute: `:row` or `:column`. This
attribute controls the direction of flow for a grid's columns or a
column's contents.

The default column direction value is `:row` to maintain backward
compatibility.