### PR TITLE
feat(page): implement theme_color attribute

### DIFF
--- a/lib/coprl/presenters/dsl/components/page.rb
+++ b/lib/coprl/presenters/dsl/components/page.rb
@@ -3,11 +3,13 @@ module Coprl
     module DSL
       module Components
         class Page < Base
-          attr_accessor :title, :background_color
+          attr_accessor :title, :background_color, :theme_color
 
           def initialize(**attribs_, &block)
-            super(type: :page,
-                  **attribs_, &block)
+            super(type: :page, **attribs_, &block)
+
+            @theme_color = attribs_.delete(:theme_color)
+
             expand!
           end
 

--- a/views/mdc/components/_page_title.erb
+++ b/views/mdc/components/_page_title.erb
@@ -1,4 +1,4 @@
-<h1 id=<%= comp.id %> class="v-page-title">
+<h1 id="<%= comp.id %>" class="v-page-title">
   <%= partial "components/render", :locals => {:components => comp.components, :scope => nil} if comp.components.any? %>
   <%= expand_text(comp.text) %>
 </h1>

--- a/views/mdc/layout.erb
+++ b/views/mdc/layout.erb
@@ -7,6 +7,9 @@
   <title><%= @pom.page.title if @pom.page %></title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <% if @pom.page&.theme_color %>
+    <meta name="theme-color" content="<%= @pom.page.theme_color %>">
+  <% end %>
   <%= coprl_headers %>
 </head>
 <body class="mdc-typography">


### PR DESCRIPTION
feat(page): implement theme_color attribute

The `theme_color` attribute allows the web client to render a
`theme-color` `<meta>` tag, which hints to the OS to color browser
chrome a specific color.

For example, this code results in a red tinting on iOS Safari:

    page do
      title 'this page has a color!'
      theme_color '#f00'
    end