### PR TITLE
fix: eliminate reload slowness

### DIFF
--- a/lib/coprl/presenters/helpers.rb
+++ b/lib/coprl/presenters/helpers.rb
@@ -4,8 +4,9 @@ module Coprl
       include Helpers::Time
       include Helpers::Date
       include Helpers::Redact
+
       if defined?(::Rails)
-        include Coprl::Presenters::Helpers::Rails
+        include Helpers::Rails
       end
     end
   end

--- a/lib/coprl/presenters/helpers/rails.rb
+++ b/lib/coprl/presenters/helpers/rails.rb
@@ -1,4 +1,4 @@
-if defined?(Rails)
+if defined?(::Rails)
   module Coprl
     module Presenters
       module Helpers
@@ -38,6 +38,18 @@ if defined?(Rails)
           end
 
           alias presenter_url presenters_url
+
+          # Ensure methods called from Rails helpers (e.g. `config.asset_host`
+          # in `ActionView::Helpers::AssetUrlHelper#image_url`) are properly
+          # delegated to Rails:
+          def method_missing(name, *args)
+            if ::Rails.application.respond_to?(name)
+              trace { "delegating ##{name} to Rails.application" }
+              return ::Rails.application.public_send(name, *args)
+            end
+
+            super
+          end
         end
       end
     end

--- a/lib/coprl/presenters/helpers/rails/routes.rb
+++ b/lib/coprl/presenters/helpers/rails/routes.rb
@@ -3,7 +3,36 @@ module Coprl
     module Helpers
       module Rails
         module Routes
-          include ::Rails.application.routes.url_helpers
+          if ::Rails.env.development?
+            # Calling `Rails.application.routes.url_helpers` reconstructs the
+            # entire routing tree, which is an expensive operation. We want to
+            # avoid this behavior when COPRL reloads POMs and included helpers
+            # via the COPRL file watcher, and when POMs/helpers call standard
+            # Rails URL helper methods (e.g. `foos_path(id: 123)`).
+            #
+            # Wrapping the anonymous module returned by `#url_helpers` in this
+            # Singleton ensures the routing tree is only constructed once, on
+            # initial load, instead of on every call.
+            #
+            # Since files never change in non-development environments, this
+            # workaround is only needed in development.
+            class UrlHelper
+              include Singleton
+              include ::Rails.application.routes.url_helpers
+            end
+
+            def method_missing(name, *args)
+              if UrlHelper.instance.respond_to?(name)
+                trace { "delegating ##{name} to UrlHelper" }
+                return UrlHelper.instance.public_send(name, *args)
+              end
+
+              super
+            end
+          else
+            include ::Rails.application.routes.url_helpers
+          end
+
           def default_url_options
             ::Rails.application.config.action_controller.default_url_options || { :host => context[:base_url] ? context[:base_url] : context[:request].host_with_port }
           end


### PR DESCRIPTION
fix: eliminate reload slowness/deadlock issue

Wrap the anonymous module returned by `Rails.application.routes.url_helpers` in a `Singleton`. This ensures that the route tree is not reconstructed every time a POM/helper calls a route helper method defined by Rails.

This only affects development, as in non-development environments, files never change and are thus not reloaded by the COPRL file watcher. Outside of development, the `url_Helpers` module returned by Rails is included as normal, NOT wrapped in a `Singleton`.

---

For more info, see [here](https://travisofthenorth.com/blog/2017/12/27/rails-urlhelpers).