### PR TITLE
feat: add event support to all components

### DIFF
--- a/lib/coprl/presenters/dsl/components/avatar.rb
+++ b/lib/coprl/presenters/dsl/components/avatar.rb
@@ -2,7 +2,7 @@ module Coprl
   module Presenters
     module DSL
       module Components
-        class Avatar < EventBase
+        class Avatar < Base
           include Mixins::Tooltips
 
           attr_accessor :avatar, :color, :size, :position

--- a/lib/coprl/presenters/dsl/components/badge.rb
+++ b/lib/coprl/presenters/dsl/components/badge.rb
@@ -2,7 +2,7 @@ module Coprl
   module Presenters
     module DSL
       module Components
-        class Badge < EventBase
+        class Badge < Base
           attr_accessor :badge, :icon, :text
 
           def initialize(**attribs_, &block)

--- a/lib/coprl/presenters/dsl/components/button.rb
+++ b/lib/coprl/presenters/dsl/components/button.rb
@@ -2,7 +2,7 @@ module Coprl
   module Presenters
     module DSL
       module Components
-        class Button < EventBase
+        class Button < Base
           include Mixins::Tooltips
           include Mixins::Padding
 

--- a/lib/coprl/presenters/dsl/components/card.rb
+++ b/lib/coprl/presenters/dsl/components/card.rb
@@ -2,7 +2,7 @@ module Coprl
   module Presenters
     module DSL
       module Components
-        class Card < EventBase
+        class Card < Base
           include Mixins::Common
           include Mixins::Attaches
           include Mixins::TextFields

--- a/lib/coprl/presenters/dsl/components/chip.rb
+++ b/lib/coprl/presenters/dsl/components/chip.rb
@@ -2,7 +2,7 @@ module Coprl
   module Presenters
     module DSL
       module Components
-        class Chip < EventBase
+        class Chip < Base
           include Mixins::Tooltips
           attr_reader :icons, :color, :name, :value, :chipset_variant, :selected
 

--- a/lib/coprl/presenters/dsl/components/chipset.rb
+++ b/lib/coprl/presenters/dsl/components/chipset.rb
@@ -2,7 +2,7 @@ module Coprl
   module Presenters
     module DSL
       module Components
-        class Chipset < EventBase
+        class Chipset < Base
           include Mixins::Chips
           attr_reader :variant, :components
 

--- a/lib/coprl/presenters/dsl/components/content.rb
+++ b/lib/coprl/presenters/dsl/components/content.rb
@@ -2,7 +2,7 @@ module Coprl
   module Presenters
     module DSL
       module Components
-        class Content < EventBase
+        class Content < Base
           include Mixins::Common
           include Mixins::Attaches
           include Mixins::TextFields

--- a/lib/coprl/presenters/dsl/components/dialog.rb
+++ b/lib/coprl/presenters/dsl/components/dialog.rb
@@ -2,12 +2,11 @@ module Coprl
   module Presenters
     module DSL
       module Components
-        class Dialog < EventBase
+        class Dialog < Base
           include Mixins::Common
           include Mixins::Attaches
           include Mixins::Steppers
           include Mixins::Sliders
-          include Mixins::Event
           include Mixins::Progress
 
           attr_accessor :percent_width,

--- a/lib/coprl/presenters/dsl/components/event_base.rb
+++ b/lib/coprl/presenters/dsl/components/event_base.rb
@@ -2,14 +2,12 @@ module Coprl
   module Presenters
     module DSL
       module Components
+        # @deprecated
+        # All Components now support events and no longer need to explicitly
+        # inherit from EventBase.
         class EventBase < Base
-          include Mixins::Event
-          attr_reader :event_parent_id
-
           def initialize(**attribs_, &block)
-            super(type: :icon,
-                  **attribs_, &block)
-            @event_parent_id = @id
+            super(type: :icon, **attribs_, &block)
           end
         end
       end

--- a/lib/coprl/presenters/dsl/components/expansion_panel.rb
+++ b/lib/coprl/presenters/dsl/components/expansion_panel.rb
@@ -2,7 +2,7 @@ module Coprl
   module Presenters
     module DSL
       module Components
-        class ExpansionPanel < EventBase
+        class ExpansionPanel < Base
           include Mixins::Common
 
           attr_accessor :open
@@ -30,7 +30,7 @@ module Coprl
             @content = Content.new(parent: self, **attribs, &block)
           end
 
-          class Content < EventBase
+          class Content < Base
             include Mixins::Common
             include Mixins::Attaches
 

--- a/lib/coprl/presenters/dsl/components/form.rb
+++ b/lib/coprl/presenters/dsl/components/form.rb
@@ -2,7 +2,7 @@ module Coprl
   module Presenters
     module DSL
       module Components
-        class Form < EventBase
+        class Form < Base
           include Mixins::Append
           include Mixins::Grids
           include Mixins::TextFields

--- a/lib/coprl/presenters/dsl/components/grid.rb
+++ b/lib/coprl/presenters/dsl/components/grid.rb
@@ -2,7 +2,7 @@ module Coprl
   module Presenters
     module DSL
       module Components
-        class Grid < EventBase
+        class Grid < Base
           include Mixins::Attaches
           include Mixins::Dialogs
           include Mixins::Snackbars

--- a/lib/coprl/presenters/dsl/components/icon_base.rb
+++ b/lib/coprl/presenters/dsl/components/icon_base.rb
@@ -2,7 +2,7 @@ module Coprl
   module Presenters
     module DSL
       module Components
-        class IconBase < EventBase
+        class IconBase < Base
           include Mixins::Tooltips
           attr_reader :icon, :color, :size, :position, :hidden
 

--- a/lib/coprl/presenters/dsl/components/image.rb
+++ b/lib/coprl/presenters/dsl/components/image.rb
@@ -2,7 +2,7 @@ module Coprl
   module Presenters
     module DSL
       module Components
-        class Image < EventBase
+        class Image < Base
           include Mixins::Tooltips
 
           VALID_FIT_TYPES = %i[contain cover fill fit].freeze

--- a/lib/coprl/presenters/dsl/components/input.rb
+++ b/lib/coprl/presenters/dsl/components/input.rb
@@ -2,7 +2,7 @@ module Coprl
   module Presenters
     module DSL
       module Components
-        class Input < EventBase
+        class Input < Base
           include Mixins::Tooltips
 
           attr_reader :name,

--- a/lib/coprl/presenters/dsl/components/list.rb
+++ b/lib/coprl/presenters/dsl/components/list.rb
@@ -6,7 +6,6 @@ module Coprl
           include Mixins::Content
           include Mixins::Append
           include Mixins::Attaches
-          include Mixins::Event
 
           attr_reader :lines, :lines_only, :color, :border, :selectable, :total_lines, :dense
           attr_accessor :components

--- a/lib/coprl/presenters/dsl/components/lists/line.rb
+++ b/lib/coprl/presenters/dsl/components/lists/line.rb
@@ -3,7 +3,7 @@ module Coprl
     module DSL
       module Components
         module Lists
-          class Line < EventBase
+          class Line < Base
             extend Gem::Deprecate
             include Mixins::Tooltips
             include Mixins::Dialogs

--- a/lib/coprl/presenters/dsl/components/menu.rb
+++ b/lib/coprl/presenters/dsl/components/menu.rb
@@ -71,7 +71,7 @@ module Coprl
             end
           end
 
-          class Item < EventBase
+          class Item < Base
             include Mixins::Tooltips
             include Mixins::Typography
             include BaseMenuItem

--- a/lib/coprl/presenters/dsl/components/multi_select.rb
+++ b/lib/coprl/presenters/dsl/components/multi_select.rb
@@ -20,7 +20,7 @@ module Coprl
                                     **attribs.delete_if{ |k,v| [:tag, :name, :input_tag].include?(k) }, &block)
           end
 
-          class CheckOption < EventBase
+          class CheckOption < Base
 
             attr_reader :selected, :disabled
 

--- a/lib/coprl/presenters/dsl/components/snackbar.rb
+++ b/lib/coprl/presenters/dsl/components/snackbar.rb
@@ -16,7 +16,7 @@ module Coprl
             @action = Action.new(parent: self, text: text, &block)
           end
 
-          class Action < EventBase
+          class Action < Base
             attr_accessor :text
 
             def initialize(**attribs_, &block)

--- a/lib/coprl/presenters/dsl/components/tab_bar.rb
+++ b/lib/coprl/presenters/dsl/components/tab_bar.rb
@@ -15,7 +15,7 @@ module Coprl
             @tabs << Tab.new(parent: self, label: label, **attribs, &block)
           end
 
-          class Tab < EventBase
+          class Tab < Base
             include Mixins::Common
 
             attr_accessor :components, :label, :icon, :stacked, :selected

--- a/lib/coprl/presenters/dsl/components/table.rb
+++ b/lib/coprl/presenters/dsl/components/table.rb
@@ -4,7 +4,7 @@ module Coprl
       module Components
         class Table < Base
           include Mixins::Common
-          include Mixins::Event
+
           attr_accessor :header, :rows, :selectable, :width, :border
 
           def initialize(**attribs_, &block)
@@ -66,7 +66,7 @@ module Coprl
                                                    &block)
             end
 
-            class Column < EventBase
+            class Column < Base
               include Mixins::Tooltips
               include Mixins::Chipset
               include Mixins::Selects

--- a/lib/coprl/presenters/dsl/components/typography.rb
+++ b/lib/coprl/presenters/dsl/components/typography.rb
@@ -2,7 +2,7 @@ module Coprl
   module Presenters
     module DSL
       module Components
-        class Typography < EventBase
+        class Typography < Base
           include Mixins::Tooltips
 
           attr_accessor :text, :level, :color, :position, :inline, :markdown

--- a/lib/coprl/presenters/generators/templates/plugin/lib/coprl/presenters/plugins/components/component.rb.tt
+++ b/lib/coprl/presenters/generators/templates/plugin/lib/coprl/presenters/plugins/components/component.rb.tt
@@ -1,10 +1,8 @@
-require 'coprl/presenters/dsl/components/event_base'
-
 module Coprl
   module Presenters
     module Plugins
       module <%= classify(name) %>
-        class <%= classify(name) %>Component < DSL::Components::EventBase
+        class <%= classify(name) %>Component < DSL::Components::Base
           attr_reader :random_fact
           def initialize(random_fact, **attribs_, &block)
             @random_fact = random_fact

--- a/views/mdc/components/_event.erb
+++ b/views/mdc/components/_event.erb
@@ -1,12 +1,13 @@
-<% if events
-     require_relative "actions/resolver"
-     data_events = events.map do |event|
-       [event.event,
-        event.actions.map do |action|
-          action_proc = WebClient::Actions::Resolver.new(comp, action).resolve
-          action_proc.call(action, parent_id, @grid_nesting, comp)
-        end,
-       {once: false}]
-     end %>
-  data-events = '<%= data_events.to_json %>'
-<% end %>
+<%
+  return unless events && comp
+
+  require_relative 'actions/resolver'
+
+  data_events = events.map do |event|
+    actions = event.actions.map do |action|
+      action_proc = WebClient::Actions::Resolver.new(comp, action).resolve
+      action_proc.call(action, parent_id, @grid_nesting, comp)
+    end
+    [event.event, actions, {once: false}]
+  end
+%>data-events="<%= h data_events.to_json %>"


### PR DESCRIPTION
feat: add event support to all components

All components extending from the `Base` component now support events and no longer need to explicitly extend `EventBase`.

`EventBase` has itself been deprecated (though remains intact to avoid breaking changes in external plugins).