### PR TITLE
feat(css): add v-hidden-- classes for screen sizes

### DIFF
--- a/public/bundle.css
+++ b/public/bundle.css
@@ -7335,7 +7335,7 @@ svg.mdc-button__icon {
   /* @alternate */
   background-color: var(--mdc-theme-secondary, #E58D36); }
 
-@keyframes mdc-checkbox-fade-in-background-u560bc96a {
+@keyframes mdc-checkbox-fade-in-background-u90c9838b {
   0% {
     border-color: rgba(0, 0, 0, 0.54);
     background-color: transparent; }
@@ -7347,7 +7347,7 @@ svg.mdc-button__icon {
     /* @alternate */
     background-color: var(--mdc-theme-secondary, #E58D36); } }
 
-@keyframes mdc-checkbox-fade-out-background-u560bc96a {
+@keyframes mdc-checkbox-fade-out-background-u90c9838b {
   0%,
   80% {
     border-color: #E58D36;
@@ -7361,10 +7361,10 @@ svg.mdc-button__icon {
     background-color: transparent; } }
 
 .mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-in-background-u560bc96a; }
+  animation-name: mdc-checkbox-fade-in-background-u90c9838b; }
 
 .mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-out-background-u560bc96a; }
+  animation-name: mdc-checkbox-fade-out-background-u90c9838b; }
 
 .mdc-checkbox__checkmark {
   color: #fff; }
@@ -14345,7 +14345,7 @@ button.mdc-chip {
   /* @alternate */
   background-color: var(--mdc-theme-primary, #5488b2); }
 
-@keyframes mdc-checkbox-fade-in-background-u9c178962 {
+@keyframes mdc-checkbox-fade-in-background-uce548263 {
   0% {
     border-color: rgba(0, 0, 0, 0.54);
     background-color: transparent; }
@@ -14357,7 +14357,7 @@ button.mdc-chip {
     /* @alternate */
     background-color: var(--mdc-theme-primary, #5488b2); } }
 
-@keyframes mdc-checkbox-fade-out-background-u9c178962 {
+@keyframes mdc-checkbox-fade-out-background-uce548263 {
   0%,
   80% {
     border-color: #5488b2;
@@ -14373,12 +14373,12 @@ button.mdc-chip {
 .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-unchecked-checked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-unchecked-indeterminate .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-in-background-u9c178962; }
+  animation-name: mdc-checkbox-fade-in-background-uce548263; }
 
 .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background, .mdc-data-table__header-row-checkbox.mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-checked-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background,
 .mdc-data-table__row-checkbox.mdc-checkbox--anim-indeterminate-unchecked .mdc-checkbox__native-control:enabled ~ .mdc-checkbox__background {
-  animation-name: mdc-checkbox-fade-out-background-u9c178962; }
+  animation-name: mdc-checkbox-fade-out-background-uce548263; }
 
 .mdc-data-table .mdc-list-item__graphic {
   margin-right: 0px; }
@@ -17434,8 +17434,19 @@ i:focus.v-datetime--clear {
   margin-bottom: 5px; }
 
 .v-hidden {
-  display: none;
-  visibility: hidden; }
+  display: none !important; }
+
+@media (max-width: 479px) {
+  .v-hidden--phone {
+    display: none !important; } }
+
+@media (min-width: 480px) and (max-width: 839px) {
+  .v-hidden--tablet {
+    display: none !important; } }
+
+@media (min-width: 840px) {
+  .v-hidden--desktop {
+    display: none !important; } }
 
 div.mdc-text-field-helper-text.mdc-text-field-helper-text--persistent.v-hidden {
   display: none;

--- a/views/mdc/assets/scss/styles.scss
+++ b/views/mdc/assets/scss/styles.scss
@@ -1,3 +1,5 @@
+@import 'node_modules/@material/layout-grid/mixins';
+
 .v-actionable {
     cursor: pointer;
 }
@@ -12,8 +14,25 @@
 }
 
 .v-hidden {
-    display: none;
-    visibility: hidden;
+    display: none !important;
+}
+
+@include mdc-layout-grid-media-query_(phone) {
+    .v-hidden--phone {
+        display: none !important;
+    }
+}
+
+@include mdc-layout-grid-media-query_(tablet) {
+    .v-hidden--tablet {
+        display: none !important;
+    }
+}
+
+@include mdc-layout-grid-media-query_(desktop) {
+    .v-hidden--desktop {
+        display: none !important;
+    }
 }
 
 div.mdc-text-field-helper-text.mdc-text-field-helper-text--persistent.v-hidden {


### PR DESCRIPTION
`v-hidden--phone`, `v-hidden--tablet`, and `v-hidden--desktop` work the same as the `v-hidden` class, but hide elements only when their respective screen size media query is satisfied.