### PR TITLE
Add Page `base_url` attribute

### DIFF
--- a/lib/coprl/presenters/dsl/components/page.rb
+++ b/lib/coprl/presenters/dsl/components/page.rb
@@ -3,12 +3,13 @@ module Coprl
     module DSL
       module Components
         class Page < Base
-          attr_accessor :title, :header, :background_color, :theme_color
+          attr_accessor :title, :header, :background_color, :theme_color, :base_url
 
           def initialize(**attribs_, &block)
             super(type: :page, **attribs_, &block)
 
             @theme_color = attribs_.delete(:theme_color)
+            @base_url = attribs_.delete(:base_url) { '/' }
 
             expand!
           end

--- a/lib/coprl/presenters/web_client/helpers/headers.rb
+++ b/lib/coprl/presenters/web_client/helpers/headers.rb
@@ -27,9 +27,13 @@ module Coprl
 
           def asset_url(path)
             asset_host = Settings.config.presenters.web_client.asset_host
-            asset_host = asset_host.call(request) if asset_host.respond_to?(:call)
 
-            "#{asset_host}/#{path}"
+            if asset_host
+              asset_host = asset_host.call(request) if asset_host.respond_to?(:call)
+              path = "#{asset_host}/#{path}"
+            end
+
+            path
           end
 
           def plugin_headers(pom)

--- a/views/mdc/layout.erb
+++ b/views/mdc/layout.erb
@@ -1,7 +1,10 @@
+<%
+  base_url = @pom.page&.base_url || '/'
+%>
 <!doctype html>
 <html class="no-js incompatible-browser" lang="en">
 <head>
-  <base href="/">
+  <base href="<%= base_url %>">
   <meta charset="utf-8">
   <meta http-equiv="x-ua-compatible" content="ie=edge">
   <title><%= @pom.page.title if @pom.page %></title>


### PR DESCRIPTION
## feat(page): Add `base_url` attribute 

If a base URL is specified, the web client renders a `<base>` element in the page's `<head>`. For example, the following POM

```ruby
page base_url: 'https://example.com'
```

is rendered by the web client as this HTML:

```html
<head>
    <base href="https://example.com">
    <!-- ... -->
</head>
```
The default base URL remains `/` to maintain backward compatibility.
  
## fix(web client): Allow for relative asset URLs 

If no `asset_host` is configured, omit the leading `/` when loading assets in POMs to allow relative URLs to utilize a `Page#base_url` if present.