### PR TITLE
feat: Allow caller to specify host for actions

### DIFF
--- a/lib/coprl/presenters/helpers/determine_host.rb
+++ b/lib/coprl/presenters/helpers/determine_host.rb
@@ -1,0 +1,18 @@
+module Coprl
+  module Presenters
+    module Helpers
+      module DetermineHost
+        def determine_host(host, default:)
+          case host
+          when true
+            default
+          when false
+            nil
+          else
+            host
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/coprl/presenters/helpers/rails.rb
+++ b/lib/coprl/presenters/helpers/rails.rb
@@ -8,17 +8,19 @@ if defined?(::Rails)
           include ModelTable
           include Routes
           include Namespace
+          include DetermineHost
 
           def presenters_path(presenter, host: false, **params)
             presenter = _expand_namespace_(presenter, namespace)
             presenter = presenter.gsub(':', '/')
+            host = determine_host(host, default: router.base_url)
 
             path = if defined?(coprl_presenters_rails_engine_url)
-              host ? coprl_presenters_rails_engine_url(params, host: router.base_url) :
-                       coprl_presenters_rails_engine_path(params)
+              host ? coprl_presenters_rails_engine_url(**params, host: host) :
+                       coprl_presenters_rails_engine_path(**params)
             else
-              host ? coprl_presenters_web_client_app_url(params, host: router.base_url) :
-                       coprl_presenters_web_client_app_path(params)
+              host ? coprl_presenters_web_client_app_url(**params, host: host) :
+                       coprl_presenters_web_client_app_path(**params)
             end
 
             if path.include?('?')

--- a/lib/coprl/presenters/router.rb
+++ b/lib/coprl/presenters/router.rb
@@ -2,58 +2,60 @@ require 'rack'
 
 module Coprl
   module Presenters
-      class Router
+    class Router
+      include Helpers::DetermineHost
 
-        attr_reader :base_url
+      attr_reader :base_url
 
-        def initialize(base_url: nil)
-          @base_url = base_url
+      def initialize(base_url: nil)
+        @base_url = base_url
+      end
+
+      def url(command: nil, render: nil, host: false, context:)
+        _params_ = context.dup
+        return build_render_url(render, _params_, host: host) unless command
+        _params_[:redirect]=build_render_url(render, _params_) if render
+        build_command_url(command, _params_)
+      end
+
+      def scrub_params(_params_)
+        _params_.delete('captures')
+        _params_.delete('presenter')
+        _params_.delete('action')
+        _params_.delete('errors')
+        _params_
+      end
+
+      private
+
+      def build_command_url(command, params)
+        return '' unless command
+        add_query_params(command, params)
+      end
+
+      def build_render_url(render_, params, host:)
+        return '#' unless render_
+        render = render_.to_s
+        return render if render.start_with?('http')
+        render = render.gsub(':', '/')
+        seperator = render.start_with?('/') ? '' : '/'
+        host = determine_host(host, default: base_url)
+        url = "#{host}#{seperator}#{render}"
+        add_query_params(url, params)
+      end
+
+      def add_query_params(url, params)
+        query_params = build_params(params)
+        if (!query_params.nil? && !query_params.empty?)
+          query_seperator = url.include?('?') ? '&' : '?'
+          url = "#{url}#{query_seperator}#{query_params}"
         end
+        url
+      end
 
-        def url(command: nil, render: nil, host: false, context:)
-          _params_ = context.dup
-          return build_render_url(render, _params_, host: host) unless command
-          _params_[:redirect]=build_render_url(render, _params_) if render
-          build_command_url(command, _params_)
-        end
-
-        def scrub_params(_params_)
-          _params_.delete('captures')
-          _params_.delete('presenter')
-          _params_.delete('action')
-          _params_.delete('errors')
-          _params_
-        end
-
-        private
-
-        def build_command_url(command, params)
-          return '' unless command
-          add_query_params(command, params)
-        end
-
-        def build_render_url(render_, params, host:)
-          return '#' unless render_
-          render = render_.to_s
-          return render if render.start_with?('http')
-          render = render.gsub(':', '/')
-          seperator = render.start_with?('/') ? '' : '/'
-          url = "#{host ? base_url : nil}#{seperator}#{render}"
-          add_query_params(url, params)
-        end
-
-        def add_query_params(url, params)
-          query_params = build_params(params)
-          if (!query_params.nil? && !query_params.empty?)
-            query_seperator = url.include?('?') ? '&' : '?'
-            url = "#{url}#{query_seperator}#{query_params}"
-          end
-          url
-        end
-
-        def build_params(params)
-          Rack::Utils.build_nested_query(scrub_params(params))
-        end
+      def build_params(params)
+        Rack::Utils.build_nested_query(scrub_params(params))
       end
     end
   end
+end


### PR DESCRIPTION
When invoking a COPRL action, such as `replaces`, previously the caller could provide `host: true` to have COPRL prepend the router's `base_url` to the action's URL.

This change allows callers to specify a non-boolean value for `host`, resulting in a fully-qualified action URL using the provided value as the host name instead of the router's base URL.

For example, if we're hosting a COPRL sinatra app on https://example.com:
```ruby
event :click do
  replaces :something, :some_other_thing, host: 'https://google.com' # replaces :something with 'https://google.com/some_other_thing'
  replaces :something, :some_other_thing, host: true # replaces :something with 'https://example.com/some_other_thing'
  replaces :something, :some_other_thing, host: false # replaces :something with '/some_other_thing'
  replaces :something, :some_other_thing              # same as above; the default behavior
end
```