### PR TITLE
fix: digest asset file contents instead of paths

### DIFF
--- a/lib/coprl/presenters/web_client/custom_css.rb
+++ b/lib/coprl/presenters/web_client/custom_css.rb
@@ -30,7 +30,7 @@ module Coprl
 
           [global_css, global_namespace_css(path), presenter_css(path)].compact.map do |path|
             path_without_public = path.sub('public/', '')
-            digest = Digest::SHA1.hexdigest(path)
+            digest = Digest::SHA1.file(path).hexdigest
             pathname = Pathname.new(File.expand_path(path_without_public))
             {path: pathname, digest: digest}
           end


### PR DESCRIPTION
This was a silly typo.