### PR TITLE
web client: fixes for errors

### DIFF
--- a/public/bundle.css
+++ b/public/bundle.css
@@ -17427,11 +17427,13 @@ i:focus.v-datetime--clear {
 
 .v-error-message {
   color: #d50000;
-  padding: 20px;
+  background: #ffd5d5;
+  padding: var(--v-padding2);
   border: 1px solid #d50000;
-  font-weight: bold;
-  border-radius: 5px;
-  margin-bottom: 5px; }
+  font-weight: 600;
+  border-radius: 4px;
+  margin-bottom: 5px;
+  word-wrap: break-word; }
 
 .v-hidden {
   display: none !important; }

--- a/public/bundle.js
+++ b/public/bundle.js
@@ -6882,9 +6882,35 @@ var VErrors = function () {
             }
 
             var newDiv = document.createElement('div');
-
             newDiv.classList.add('v-error-message');
-            newDiv.insertAdjacentHTML('beforeend', messages.join('<br>'));
+            var fragment = document.createDocumentFragment();
+
+            var _iteratorNormalCompletion2 = true;
+            var _didIteratorError2 = false;
+            var _iteratorError2 = undefined;
+
+            try {
+                for (var _iterator2 = messages[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+                    var message = _step2.value;
+
+                    fragment.appendChild(document.createTextNode(message));
+                }
+            } catch (err) {
+                _didIteratorError2 = true;
+                _iteratorError2 = err;
+            } finally {
+                try {
+                    if (!_iteratorNormalCompletion2 && _iterator2.return) {
+                        _iterator2.return();
+                    }
+                } finally {
+                    if (_didIteratorError2) {
+                        throw _iteratorError2;
+                    }
+                }
+            }
+
+            newDiv.appendChild(fragment);
 
             // add the newly created element and its content into the DOM
             errorsDiv.insertAdjacentElement('beforebegin', newDiv);

--- a/public/wc.js
+++ b/public/wc.js
@@ -3978,9 +3978,35 @@ var VErrors = function () {
             }
 
             var newDiv = document.createElement('div');
-
             newDiv.classList.add('v-error-message');
-            newDiv.insertAdjacentHTML('beforeend', messages.join('<br>'));
+            var fragment = document.createDocumentFragment();
+
+            var _iteratorNormalCompletion2 = true;
+            var _didIteratorError2 = false;
+            var _iteratorError2 = undefined;
+
+            try {
+                for (var _iterator2 = messages[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+                    var message = _step2.value;
+
+                    fragment.appendChild(document.createTextNode(message));
+                }
+            } catch (err) {
+                _didIteratorError2 = true;
+                _iteratorError2 = err;
+            } finally {
+                try {
+                    if (!_iteratorNormalCompletion2 && _iterator2.return) {
+                        _iterator2.return();
+                    }
+                } finally {
+                    if (_didIteratorError2) {
+                        throw _iteratorError2;
+                    }
+                }
+            }
+
+            newDiv.appendChild(fragment);
 
             // add the newly created element and its content into the DOM
             errorsDiv.insertAdjacentElement('beforebegin', newDiv);

--- a/views/mdc/assets/js/components/events/errors.js
+++ b/views/mdc/assets/js/components/events/errors.js
@@ -202,9 +202,14 @@ export class VErrors {
         }
 
         const newDiv = document.createElement('div');
-
         newDiv.classList.add('v-error-message');
-        newDiv.insertAdjacentHTML('beforeend', messages.join('<br>'));
+        const fragment = document.createDocumentFragment();
+
+        for (const message of messages) {
+            fragment.appendChild(document.createTextNode(message));
+        }
+
+        newDiv.appendChild(fragment);
 
         // add the newly created element and its content into the DOM
         errorsDiv.insertAdjacentElement('beforebegin', newDiv);

--- a/views/mdc/assets/scss/styles.scss
+++ b/views/mdc/assets/scss/styles.scss
@@ -6,11 +6,13 @@
 
 .v-error-message {
     color: $v-theme-error-message;
-    padding: 20px;
+    background: lighten($v-theme-error-message, 50%);
+    padding: var(--v-padding2);
     border: 1px solid $v-theme-error-message;
-    font-weight: bold;
-    border-radius: 5px;
+    font-weight: 600;
+    border-radius: 4px;
     margin-bottom: 5px;
+    word-wrap: break-word;
 }
 
 .v-hidden {

--- a/views/mdc/components/_card.erb
+++ b/views/mdc/components/_card.erb
@@ -18,7 +18,7 @@
   data-is-container>
     <%= partial("components/progress", :locals => {:comp => comp.progress}) if comp.progress && includes_one?(Array(comp.progress.position), %i(top both)) %>
     <% if comp.media %>
-      <div class="v-errors">
+      <div class="<% if comp.shows_errors %>v-errors<% end %>">
         <div id="<%= comp.media.id %>"
              class="mdc-card__media v-card-media
                 <%= 'v-hidden' if comp.media.hidden %>
@@ -35,7 +35,7 @@
         </div>
       </div>
     <% end %>
-    <div class="v-errors" style="<%= "height: #{comp.height};" if comp.height %>">
+    <div class="<% if comp.shows_errors %>v-errors<% end %>" style="<%= "height: #{comp.height};" if comp.height %>">
       <% if comp.components.any? %>
         <div class="v-card-content <%= padding_classes(comp.padding, subclass: :col) %>"
              style="<%= "height: #{comp.height};" if comp.height %>">

--- a/views/mdc/components/_dialog.erb
+++ b/views/mdc/components/_dialog.erb
@@ -29,7 +29,7 @@
       <% end %>
 
       <div class="mdc-dialog__content" id="<%= comp.id %>-content">
-        <div class="v-errors">
+        <div class="<% if comp.shows_errors %>v-errors<% end %>">
           <%= partial "components/render", :locals => {:components => comp.components, :scope => nil} if comp.components.any? %>
           <% if dialog_action_buttons.any? %>
             <footer class="mdc-dialog__actions">

--- a/views/mdc/components/_form.erb
+++ b/views/mdc/components/_form.erb
@@ -8,7 +8,7 @@
       onsubmit="javascript:void(0);return false;"
       <%= partial "components/event", :locals => {comp: comp, events: comp.events, parent_id: comp.id} if comp.events&.any? %>
       data-is-container>
-  <div class="v-errors">
+  <div class="<% if comp.shows_errors %>v-errors<% end %>">
     <%= partial "components/render", :locals => {:components => comp.components, :scope => nil} if comp.components.any? %>
   </div>
 </form>


### PR DESCRIPTION
### Fix `shows_errors` for cards, dialogs, forms

Cards, dialogs, and forms accept a `shows_errors` parameter but do not do anything with it. This change ensures the web client renders the correct output HTML for these components when `shows_errors` is off.

### Add background to errors div

Gives the errors `<div>` a light red background color so it appears consistent regardless of its parent.

### Miscellaneous

* use `DocumentFragment` to render errors